### PR TITLE
don't leave lua to join strings

### DIFF
--- a/lua/texpresso.lua
+++ b/lua/texpresso.lua
@@ -55,7 +55,7 @@ local function buffer_get_lines(buf, first, last)
   if first == last then
     return ""
   else
-    return vim.fn.join(vim.api.nvim_buf_get_lines(buf, first, last, false), "\n") .. "\n"
+    return table.concat(vim.api.nvim_buf_get_lines(buf, first, last, false), "\n") .. "\n"
   end
 end
 


### PR DESCRIPTION
Tiny nit which which makes the operation 10x-20x faster. Skips a marshalling step between runtimes.

If that last `.. '\n'` is further replaced by appending a `' '` to the table, it skips reallocating the buffer-sized string. But I didn't think that the few % improvement was worth uglifying the code.