### PR TITLE
Add stylua config and format

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 100
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferSingle"
+call_parentheses = "Input"

--- a/lua/texpresso.lua
+++ b/lua/texpresso.lua
@@ -225,7 +225,6 @@ end
 
 -- Attach a hook to synchronize a buffer
 function M.attach(...)
-  local let
   local args = { ... }
   local buf = args[1] or 0
   local generation = job.generation

--- a/lua/texpresso.lua
+++ b/lua/texpresso.lua
@@ -226,7 +226,7 @@ end
 -- Attach a hook to synchronize a buffer
 function M.attach(...)
   local let
-  args = { ... }
+  local args = { ... }
   local buf = args[1] or 0
   local generation = job.generation
   M.reload(buf)

--- a/lua/texpresso.lua
+++ b/lua/texpresso.lua
@@ -354,7 +354,7 @@ vim.api.nvim_create_autocmd('ColorScheme', {
 })
 
 vim.api.nvim_create_autocmd('CursorMoved', {
-  pattern = { '*.tex' },
+  pattern = '*.tex',
   callback = M.synctex_forward_hook,
 })
 

--- a/lua/texpresso.lua
+++ b/lua/texpresso.lua
@@ -299,7 +299,7 @@ function M.launch(args)
   if job.process then
     vim.fn.chanclose(job.process)
   end
-  cmd = { M.texpresso_path, '-json', '-lines' }
+  local cmd = { M.texpresso_path, '-json', '-lines' }
 
   if #args == 0 then
     args = M.last_args

--- a/lua/texpresso.lua
+++ b/lua/texpresso.lua
@@ -230,14 +230,14 @@ function M.attach(...)
   local generation = job.generation
   M.reload(buf)
   vim.api.nvim_buf_attach(buf, false, {
-    on_detach = function(_detach, buf)
+    on_detach = function(_, buf)
       M.send('close', vim.api.nvim_buf_get_name(buf))
     end,
-    on_reload = function(_reload, buf)
+    on_reload = function(_, buf)
       M.reload(buf)
       generation = job.generation
     end,
-    on_lines = function(_lines, buf, _tick, first, oldlast, newlast, _bytes)
+    on_lines = function(_, buf, _, first, oldlast, newlast, _)
       if generation == job.generation then
         M.change_lines(buf, first, oldlast - first, newlast)
       else
@@ -270,7 +270,7 @@ end
 
 -- Go to the page under the cursor
 function M.synctex_forward()
-  local line, _col = unpack(vim.api.nvim_win_get_cursor(0))
+  local line, _ = unpack(vim.api.nvim_win_get_cursor(0))
   local file = vim.api.nvim_buf_get_name(0)
   M.send('synctex-forward', file, line)
 end
@@ -284,7 +284,7 @@ function M.synctex_forward_hook()
     return
   end
 
-  local line, _col = unpack(vim.api.nvim_win_get_cursor(0))
+  local line, _ = unpack(vim.api.nvim_win_get_cursor(0))
   local file = vim.api.nvim_buf_get_name(0)
   if last_line == line and last_file == file then
     return
@@ -316,7 +316,7 @@ function M.launch(args)
   end
   job.queued = ''
   job.process = vim.fn.jobstart(cmd, {
-    on_stdout = function(j, data, e)
+    on_stdout = function(_, data, _)
       if job.queued then
         data[1] = job.queued .. data[1]
       end
@@ -332,7 +332,7 @@ function M.launch(args)
         end
       end
     end,
-    on_stderr = function(j, d, e)
+    on_stderr = function(_, d, _)
       local buf = log_buffer()
       buffer_append(buf, d)
       if vim.api.nvim_buf_line_count(buf) > 8000 then

--- a/lua/texpresso.lua
+++ b/lua/texpresso.lua
@@ -253,9 +253,9 @@ end
 
 -- Use VIM theme in TeXpresso
 function M.theme()
-  local colors = vim.api.nvim_get_hl_by_name('Normal', true)
-  if colors.background and colors.foreground then
-    M.send('theme', format_color(colors.background), format_color(colors.foreground))
+  local colors = vim.api.nvim_get_hl(0, { name = 'Normal' })
+  if colors.bg and colors.fg then
+    M.send('theme', format_color(colors.bg), format_color(colors.fg))
   end
 end
 


### PR DESCRIPTION
Edit: I hope you don't mind multiple changes in one pull request, seems I don't really understand the github cli all too well. I'll try add any comments about changes to their respective commits.

This adds a stylua config, `.stylua.toml`, found in and copied from the [neovim/neovim](https://github.com/neovim/neovim) repository. Afaik stylua is the informal standard for formatting lua in the context of neovim and the stylua config used for the neovim repo itself seems like a good default. This then brings the formatting of `texpresso.vim` in line with other neovim plugins.