### PR TITLE
Codebase cleanup

### DIFF
--- a/lua/texpresso.lua
+++ b/lua/texpresso.lua
@@ -114,12 +114,12 @@ end
 local function format_fix(line)
   local typ, f, l, txt
   typ, f, l, txt = string.match(line, "([a-z]+): (.*):(%d*): (.*)")
-  if string.match(txt, "^Overfull") or string.match(txt, "^Underfull") then
-    return {}
-  elseif typ then
-    return { type = typ, filename = f, lnum = l, text = txt }
-  else
+  if not typ then
     return { text = line }
+  elseif string.match(txt, "^Overfull") or string.match(txt, "^Underfull") then
+    return {}
+  else
+    return { type = typ, filename = f, lnum = l, text = txt }
   end
 end
 

--- a/lua/texpresso.lua
+++ b/lua/texpresso.lua
@@ -215,7 +215,7 @@ end
 
 -- Attach a hook to synchronize a buffer
 function M.attach(...)
-  local let args = {...}
+  local args = {...}
   local buf = args[1] or 0
   local generation = job.generation
   M.reload(buf)
@@ -242,12 +242,12 @@ end
 
 -- Use VIM theme in TeXpresso
 function M.theme()
-  local colors = vim.api.nvim_get_hl_by_name("Normal", true)
-  if colors.background and colors.foreground then
+  local colors = vim.api.nvim_get_hl(0, { name = "Normal" })
+  if colors.bg and colors.fg then
     M.send(
       "theme",
-      format_color(colors.background),
-      format_color(colors.foreground)
+      format_color(colors.bg),
+      format_color(colors.fg)
     )
   end
 end
@@ -293,7 +293,7 @@ function M.launch(args)
   if job.process then
     vim.fn.chanclose(job.process)
   end
-  cmd = {M.texpresso_path, "-json", "-lines"}
+  local cmd = {M.texpresso_path, "-json", "-lines"}
 
   if #args == 0 then
     args = M.last_args


### PR DESCRIPTION
Hey! 

I have reviewed the project and spot several issues which I would like to resolve, here is the list:

1. Remove extra `let` variable declaration (line 218): `local let args` to `local args`
2. Add missing `local` to `cmd` (line 296): without it, we do global scope pollution
3. Replace deprecated `nvim_get_hl_by_name` (line 245): Neovim 0.9+ now use `nvim_get_hl(0, { name = "Normal" })` with updated field names (`bg/fg` instead of `background/foreground`)
4. Fix `nil` crash in `format_fix` (line 117): the Overfull/Underfull filter called `string.match(txt, ...)` before checking if the regex matched, crashing when `txt` was `nil`. I have reordered if clauses to check `typ` first

These are not critical, but fixing those is highly recommended, the plugin logic and performance are not affected.